### PR TITLE
App crash when creates an ImageView without Image

### DIFF
--- a/toga_cocoa/widgets/imageview.py
+++ b/toga_cocoa/widgets/imageview.py
@@ -56,4 +56,8 @@ class ImageView(ImageViewInterface, WidgetMixin):
         if image:
             self._impl.image = image._impl
         else:
-            self._impl.image = NSImage.alloc().initWithSize_(NSSize(self.width, self.height))
+            width = height = 0
+            if self.style and self.style.width and self.style.height:
+                width = self.style.width
+                height = self.style.height
+            self._impl.image = NSImage.alloc().initWithSize_(NSSize(width, height))


### PR DESCRIPTION
In this case, image setter of ImageView tries to access to non-existent attributes (width and height). I replaced those attributes by CSS width and height (if they exist).
At the end, the result is the same that just not creating the NSImage (nothing is rendered), but I leave the creation just in case.
